### PR TITLE
Always show header anchor links

### DIFF
--- a/djangoproject/scss/_style.scss
+++ b/djangoproject/scss/_style.scss
@@ -2041,7 +2041,6 @@ h2 + .list-link-soup {
 
 .headerlink {
     // Permalink styles for sections in docs
-    opacity: 0;
     padding-left: 10px;
     font-size: 0.8em;
     position: relative;
@@ -2051,21 +2050,6 @@ h2 + .list-link-soup {
     -webkit-transition: opacity 200ms ease-in-out;
     transition: opacity 200ms ease-in-out;
 }
-
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6,
-    dl,
-    dt {
-        &:hover {
-            > .headerlink {
-                opacity: 1;
-            }
-        }
-    }
 
 //Notes, help blocks, and annotation sections
 .note,


### PR DESCRIPTION
Another approach on #986.  We can’t tell links are there if they are invisible. For documentation, being able to link to a specific section is really useful – let’s just always have those header anchor link indicators visible on the site.